### PR TITLE
Integrate Kavenegar OTP delivery

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -69,6 +69,7 @@ class Settings(BaseSettings):
     OTP_EXPIRY_MINUTES: int = 5
     OTP_PROVIDER: str = "mock"  # Options: mock, kavenegar
     KAVENEGAR_API_KEY: str | None = None
+    KAVENEGAR_OTP_TEMPLATE: str | None = None
 
     class Config:
         env_file = ".env"

--- a/backend/env.example
+++ b/backend/env.example
@@ -108,6 +108,8 @@ OTP_PROVIDER=mock
 # Kavenegar SMS API (Optional - for production)
 # Get API key from https://panel.kavenegar.com
 # KAVENEGAR_API_KEY=your-kavenegar-api-key-here
+# Set the Verify Lookup template name configured in Kavenegar panel
+# KAVENEGAR_OTP_TEMPLATE=otp-template-name
 
 # =============================================================================
 # Celery/Background Tasks (Optional - not required for basic setup)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,6 +25,7 @@ python-dotenv==1.2.1
 # HTTP Clients
 httpx==0.26.0
 requests==2.32.4
+kavenegar==1.1.3
 
 # PDF Processing
 pdfminer.six==20221105


### PR DESCRIPTION
## Summary
- integrate the Kavenegar SDK into the OTP service with environment-based credentials and template configuration
- extend backend settings and example environment variables for the Kavenegar verify lookup template
- add the official Kavenegar client to backend dependencies

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900b5adfe848320949378ee10eaeadd